### PR TITLE
Add journal option and update LLM group

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Build with [dstotijn/go-notion](https://pkg.go.dev/github.com/dstotijn/go-notion
 - `--cmd=export`: Export/backup pages in a database to markdown files (text and images)
 - `--cmd=llm`: Run a GPT prompt on a page content
   - Set `groupExec: true` in the LLM config to combine all pages in a single request
+  - Optional `groupJournalID` writes the group result to today's journal page when set


### PR DESCRIPTION
## Summary
- allow writing group results to today’s journal via `groupJournalID`
- append group output to the last scanned page when no target page is specified
- document new `groupJournalID` option

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/github.com/dstotijn/go-notion/@v/v0.11.0.mod": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843c216fba88326b5a3f79aec46d718