### PR TITLE
Bump Go requirement to 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A set of tools to automate my [Notion](https://www.notion.so/) workflow using [N
 
 Build with [dstotijn/go-notion](https://pkg.go.dev/github.com/dstotijn/go-notion).
 
+Requires **Go 1.20** or later.
+
 ## Repo Setup
 
 Clone the repository and download the Go dependencies:

--- a/example/workflow/backup.yml
+++ b/example/workflow/backup.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16.5'
+          go-version: '1.20'
 
       # Get the toolset
       - name: Get the toolset

--- a/example/workflow/daily.yml
+++ b/example/workflow/daily.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16.5'
+          go-version: '1.20'
 
       # Get the toolset
       - name: Get the toolset

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zhuochun/notion-toolset
 
-go 1.16
+go 1.20
 
 require (
 	github.com/dstotijn/go-notion v0.11.0


### PR DESCRIPTION
## Summary
- update `go.mod` to require Go 1.20
- update example workflows to use Go 1.20
- mention minimum Go version in `README.md`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843d9be1bc08326a419f3c7b83ed8b4