### PR TITLE
Add retry helper and refactor calls

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,17 @@
+package retry
+
+import "time"
+
+const Count = 3
+const Delay = time.Second
+
+func Do(fn func() error) error {
+	var err error
+	for i := 0; i < Count; i++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		time.Sleep(Delay)
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
- add `retry` package with `Do` helper and constants
- wrap Notion API calls using `retry.Do` for page, block, and database queries

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843d739430c8326baffc43c781e81ef