### PR TITLE
feat: make OpenAI URL configurable via env

### DIFF
--- a/llm.go
+++ b/llm.go
@@ -69,7 +69,15 @@ func (m *LangModel) Validate() error {
 	if openaiToken == "" {
 		return fmt.Errorf("missing token in env.DOT_OPENAI_KEY")
 	}
-	m.OpenaiClient = openai.NewClient(openaiToken)
+
+	openaiURL := os.Getenv("DOT_OPENAI_URL")
+	if openaiURL != "" {
+		cfg := openai.DefaultConfig(openaiToken)
+		cfg.BaseURL = openaiURL
+		m.OpenaiClient = openai.NewClientWithConfig(cfg)
+	} else {
+		m.OpenaiClient = openai.NewClient(openaiToken)
+	}
 
 	// set default exportspeed
 	if m.TaskSpeed < 1 {


### PR DESCRIPTION
## Summary
- allow overriding OpenAI base URL using `DOT_OPENAI_URL`

## Testing
- `go test ./...` (fails: command hung)

------
https://chatgpt.com/codex/tasks/task_e_68bd2e0bed5c832691a846a134c56dcb