### PR TITLE
Use go install in workflow examples

### DIFF
--- a/example/workflow/backup.yml
+++ b/example/workflow/backup.yml
@@ -24,8 +24,8 @@ jobs:
           go-version: '1.20'
 
       # Get the toolset
-      - name: Get the toolset
-        run: go get github.com/zhuochun/notion-toolset
+      - name: Install the toolset
+        run: go install github.com/zhuochun/notion-toolset@latest
 
       # Runs backup commands
       - name: Export database

--- a/example/workflow/daily.yml
+++ b/example/workflow/daily.yml
@@ -26,8 +26,8 @@ jobs:
           go-version: '1.20'
 
       # Get the toolset
-      - name: Get the toolset
-        run: go get github.com/zhuochun/notion-toolset
+      - name: Install the toolset
+        run: go install github.com/zhuochun/notion-toolset@latest
 
       # Run the go app
       - name: Run flashback cmd


### PR DESCRIPTION
## Summary
- replace the go get step in the backup workflow example with go install so the binary is installed under modern Go versions
- update the daily workflow example to use go install as well, ensuring notion-toolset is available in the PATH when the job runs

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc1664f8a8832684331a5eedfbab40