### PR TITLE
Slugify exporter filenames

### DIFF
--- a/export.go
+++ b/export.go
@@ -51,6 +51,8 @@ type Exporter struct {
 	exportPool   chan notion.Page
 	queryPool    chan *transformer.BlockFuture
 	downloadPool chan *transformer.AssetFuture
+
+	slugger transformer.SlugRegistry
 }
 
 func (e *Exporter) Validate() error {
@@ -323,8 +325,8 @@ func (e *Exporter) exportPage(page notion.Page) error {
 }
 
 func (e *Exporter) getExportFilename(page notion.Page) string {
-	filename := filepath.Join(e.Directory, transformer.SimpleID(page.ID)+".md")
-	// TODO slug the title?
+	slug := transformer.SimpleID(page.ID)
+
 	if e.UseTitleAsFilename {
 		if title, err := transformer.GetPageTitle(page); err == nil {
 			if len(e.ReplaceTitle) == 2 {
@@ -332,10 +334,17 @@ func (e *Exporter) getExportFilename(page notion.Page) string {
 			}
 			title = strings.TrimSpace(title)
 
-			filename = filepath.Join(e.Directory, title+".md")
+			if cleaned := transformer.SlugifyTitle(title, transformer.MaxSlugLength); cleaned != "" {
+				slug = cleaned
+			}
+
+			slug = e.slugger.Register(slug, page.ID)
+		} else {
+			slug = e.slugger.Register(slug, page.ID)
 		}
 	}
-	return filename
+
+	return filepath.Join(e.Directory, slug+".md")
 }
 
 func (e *Exporter) StartDownloader(wg *sync.WaitGroup, size int) chan *transformer.AssetFuture {

--- a/export_test.go
+++ b/export_test.go
@@ -4,9 +4,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/dstotijn/go-notion"
 	"github.com/zhuochun/notion-toolset/transformer"
 )
 
@@ -70,5 +72,113 @@ func TestDownloadAssetSupportedExtensionPDF(t *testing.T) {
 
 	if _, err := os.Stat(filename); err != nil {
 		t.Fatalf("expected file to exist: %v", err)
+	}
+}
+
+func TestGetExportFilenameSlugifiesTitle(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := &Exporter{ExporterConfig: ExporterConfig{Directory: tmpDir, UseTitleAsFilename: true}}
+
+	page := notion.Page{
+		ID: "11111111-2222-3333-4444-555555555555",
+		Properties: notion.PageProperties{
+			Title: notion.PageTitle{
+				Title: []notion.RichText{
+					{PlainText: "Hello / World*"},
+				},
+			},
+		},
+	}
+
+	filename := e.getExportFilename(page)
+	expected := filepath.Join(tmpDir, "hello-world.md")
+
+	if filename != expected {
+		t.Fatalf("expected %q, got %q", expected, filename)
+	}
+}
+
+func TestGetExportFilenameAppendsPageIDSuffixOnCollision(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := &Exporter{ExporterConfig: ExporterConfig{Directory: tmpDir, UseTitleAsFilename: true}}
+
+	pageOne := notion.Page{
+		ID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		Properties: notion.PageProperties{
+			Title: notion.PageTitle{
+				Title: []notion.RichText{
+					{PlainText: "Same Title"},
+				},
+			},
+		},
+	}
+	pageTwo := notion.Page{
+		ID: "ffffffff-1111-2222-3333-444444444444",
+		Properties: notion.PageProperties{
+			Title: notion.PageTitle{
+				Title: []notion.RichText{
+					{PlainText: "Same Title"},
+				},
+			},
+		},
+	}
+
+	first := e.getExportFilename(pageOne)
+	second := e.getExportFilename(pageTwo)
+
+	expectedFirst := filepath.Join(tmpDir, "same-title.md")
+	expectedSecond := filepath.Join(tmpDir, "same-title-ffffffff111122223333444444444444.md")
+
+	if first != expectedFirst {
+		t.Fatalf("expected %q, got %q", expectedFirst, first)
+	}
+
+	if second != expectedSecond {
+		t.Fatalf("expected %q, got %q", expectedSecond, second)
+	}
+}
+
+func TestGetExportFilenameAppendsPageIDSuffixForReservedWindowsName(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := &Exporter{ExporterConfig: ExporterConfig{Directory: tmpDir, UseTitleAsFilename: true}}
+
+	page := notion.Page{
+		ID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		Properties: notion.PageProperties{
+			Title: notion.PageTitle{
+				Title: []notion.RichText{
+					{PlainText: "CON"},
+				},
+			},
+		},
+	}
+
+	filename := e.getExportFilename(page)
+	expected := filepath.Join(tmpDir, "con-aaaaaaaabbbbccccddddeeeeeeeeeeee.md")
+
+	if filename != expected {
+		t.Fatalf("expected %q, got %q", expected, filename)
+	}
+}
+
+func TestSlugifyTitleTruncatesAndCleans(t *testing.T) {
+	longTitle := strings.Repeat("title ", 50) + `with invalid <>:"/\\|?*chars`
+
+	slug := transformer.SlugifyTitle(longTitle, 40)
+
+	if len([]rune(slug)) != 40 {
+		t.Fatalf("expected slug length 40, got %d", len([]rune(slug)))
+	}
+
+	if strings.ContainsAny(slug, "<>:\"/\\|?*") {
+		t.Fatalf("slug contains invalid characters: %q", slug)
+	}
+}
+
+func TestSlugifyTitleTrimsTrailingWindowsInvalidCharacters(t *testing.T) {
+	slug := transformer.SlugifyTitle("Title.   ", 40)
+
+	if slug != "title" {
+		t.Fatalf("expected %q, got %q", "title", slug)
 	}
 }

--- a/transformer/slug.go
+++ b/transformer/slug.go
@@ -1,0 +1,148 @@
+package transformer
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+const MaxSlugLength = 120
+
+type SlugRegistry struct {
+	mu    sync.Mutex
+	cache map[string]string
+}
+
+func SlugifyTitle(title string, maxLen int) string {
+	title = strings.TrimSpace(strings.ToLower(title))
+	if title == "" || maxLen <= 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	lastDash := false
+
+	for _, r := range title {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			builder.WriteRune(r)
+			lastDash = false
+		case r == ' ' || r == '-' || r == '_':
+			if !lastDash && builder.Len() > 0 {
+				builder.WriteRune('-')
+				lastDash = true
+			}
+		default:
+			if isInvalidFilenameRune(r) {
+				continue
+			}
+		}
+	}
+
+	slug := strings.Trim(builder.String(), "-")
+	slug = strings.TrimRight(slug, ". ")
+	return truncateRunes(slug, maxLen)
+}
+
+func (r *SlugRegistry) Register(slug string, pageID string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cache == nil {
+		r.cache = make(map[string]string)
+	}
+
+	original := slug
+	candidate := slug
+	suffix := SimpleID(pageID)
+	counter := 0
+
+	for {
+		if isReservedWindowsBasename(candidate) {
+			counter++
+			suffixValue := suffix
+			if counter > 1 {
+				suffixValue = fmt.Sprintf("%s-%d", suffix, counter)
+			}
+			candidate = appendSlugSuffix(original, suffixValue, MaxSlugLength)
+			continue
+		}
+
+		if owner, exists := r.cache[candidate]; exists {
+			if owner == pageID {
+				return candidate
+			}
+
+			counter++
+			suffixValue := suffix
+			if counter > 1 {
+				suffixValue = fmt.Sprintf("%s-%d", suffix, counter)
+			}
+			candidate = appendSlugSuffix(original, suffixValue, MaxSlugLength)
+			continue
+		}
+
+		r.cache[candidate] = pageID
+		return candidate
+	}
+}
+
+func appendSlugSuffix(slug string, suffix string, maxLen int) string {
+	if suffix == "" {
+		return truncateRunes(slug, maxLen)
+	}
+
+	delimiter := "-"
+	slugRunes := []rune(slug)
+	suffixRunes := []rune(suffix)
+	available := maxLen - len(delimiter) - len(suffixRunes)
+
+	if available < 0 {
+		available = 0
+	}
+
+	if len(slugRunes) > available {
+		slugRunes = slugRunes[:available]
+	}
+
+	if len(slugRunes) == 0 {
+		return truncateRunes(suffix, maxLen)
+	}
+
+	return fmt.Sprintf("%s%s%s", string(slugRunes), delimiter, suffix)
+}
+
+func truncateRunes(value string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+
+	runes := []rune(value)
+	if len(runes) <= maxLen {
+		return value
+	}
+
+	return string(runes[:maxLen])
+}
+
+func isInvalidFilenameRune(r rune) bool {
+	switch r {
+	case '<', '>', ':', '"', '/', '\\', '|', '?', '*':
+		return true
+	}
+
+	return unicode.IsControl(r)
+}
+
+func isReservedWindowsBasename(value string) bool {
+	trimmed := strings.TrimRight(strings.ToLower(value), ". ")
+	switch trimmed {
+	case "con", "prn", "aux", "nul",
+		"com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+		"lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- add a slugification helper to sanitize title-based export filenames and limit their length
- ensure title collisions append the page ID to keep exported filenames unique
- cover slug generation and collision handling with new tests

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69476cf0eb38832681e6d15f301be083)