### PR TITLE
Add full export deleted-page cleanup

### DIFF
--- a/example/configs/export.yaml
+++ b/example/configs/export.yaml
@@ -22,6 +22,7 @@ exporter:
 
   lookbackDays: 1
   directory: "backup/" # Write files to directory (create it first)
+  cleanupDeleted: false # Delete stale top-level markdown files only on full exports
   useTitleAsFilename: false
 
   markdown: # There might be more settings, refer to code

--- a/export.go
+++ b/export.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -28,6 +29,7 @@ type ExporterConfig struct {
 	LookbackDays       int      `yaml:"lookbackDays"`   // leave this empty for full backup
 	Directory          string   `yaml:"directory"`      // output directory
 	AssetDirectory     string   `yaml:"assetDirectory"` // output directory for assets (images, etc)
+	CleanupDeleted     bool     `yaml:"cleanupDeleted"`
 	UseTitleAsFilename bool     `yaml:"useTitleAsFilename"`
 	ReplaceTitle       []string `yaml:"replaceTitle"`
 	// transformer
@@ -51,6 +53,9 @@ type Exporter struct {
 	exportPool   chan notion.Page
 	queryPool    chan *transformer.BlockFuture
 	downloadPool chan *transformer.AssetFuture
+
+	exportedFilesMu sync.Mutex
+	exportedFiles   map[string]struct{}
 }
 
 func (e *Exporter) Validate() error {
@@ -107,6 +112,7 @@ func (e *Exporter) precheckDir(dir string) error {
 
 func (e *Exporter) Run() error {
 	e.queryLimiter = rate.NewLimiter(rate.Limit(e.ExportSpeed), int(e.ExportSpeed))
+	e.exportedFiles = map[string]struct{}{}
 
 	// workers to write markdowns
 	exportWg := new(sync.WaitGroup)
@@ -141,6 +147,10 @@ func (e *Exporter) Run() error {
 
 	close(e.queryPool)
 	queryWg.Wait()
+
+	if err := e.cleanupDeletedPages(); err != nil {
+		return err
+	}
 
 	select {
 	case err := <-errChan:
@@ -298,6 +308,7 @@ func (e *Exporter) exportPage(page notion.Page) error {
 
 	t := transformer.New(e.Markdown, &page, blocks, e.queryPool, e.downloadPool)
 	t.TransformOut(file)
+	e.trackExportedFile(filename)
 
 	// export sub-pages inside this page
 	for _, block := range blocks {
@@ -336,6 +347,98 @@ func (e *Exporter) getExportFilename(page notion.Page) string {
 		}
 	}
 	return filename
+}
+
+func (e *Exporter) trackExportedFile(filename string) {
+	e.exportedFilesMu.Lock()
+	defer e.exportedFilesMu.Unlock()
+
+	if e.exportedFiles == nil {
+		e.exportedFiles = map[string]struct{}{}
+	}
+	e.exportedFiles[filename] = struct{}{}
+}
+
+func (e *Exporter) cleanupDeletedPages() error {
+	if !e.CleanupDeleted || e.ExecOne != "" || e.LookbackDays > 0 {
+		return nil
+	}
+
+	entries, err := os.ReadDir(e.Directory)
+	if err != nil {
+		return fmt.Errorf("read export directory: %v, err: %w", e.Directory, err)
+	}
+
+	exportedFiles := e.snapshotExportedFiles()
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() || !isManagedMarkdownFile(entry.Name()) {
+			continue
+		}
+
+		filename := filepath.Join(e.Directory, entry.Name())
+		if _, ok := exportedFiles[filename]; ok {
+			continue
+		}
+
+		if err := e.removeManagedFile(filename, e.Directory); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Exporter) snapshotExportedFiles() map[string]struct{} {
+	e.exportedFilesMu.Lock()
+	defer e.exportedFilesMu.Unlock()
+
+	snapshot := make(map[string]struct{}, len(e.exportedFiles))
+	for filename := range e.exportedFiles {
+		snapshot[filename] = struct{}{}
+	}
+	return snapshot
+}
+
+func isManagedMarkdownFile(name string) bool {
+	return filepath.Ext(name) == ".md" && !strings.HasPrefix(name, ".")
+}
+
+func (e *Exporter) removeManagedFile(filename, rootDir string) error {
+	if filename == "" {
+		return nil
+	}
+
+	managed, err := isManagedPath(rootDir, filename)
+	if err != nil {
+		return fmt.Errorf("validate managed path: %v, err: %w", filename, err)
+	}
+	if !managed {
+		return fmt.Errorf("refuse to delete file outside export directory: %v", filename)
+	}
+	if err := os.Remove(filename); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete exported file: %v, err: %w", filename, err)
+	}
+
+	if e.DebugMode {
+		log.Printf("Deleted stale export: %v", filename)
+	}
+	return nil
+}
+
+func isManagedPath(rootDir, filename string) (bool, error) {
+	rootAbs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return false, err
+	}
+	fileAbs, err := filepath.Abs(filename)
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(rootAbs, fileAbs)
+	if err != nil {
+		return false, err
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)), nil
 }
 
 func (e *Exporter) StartDownloader(wg *sync.WaitGroup, size int) chan *transformer.AssetFuture {

--- a/export_test.go
+++ b/export_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -70,5 +71,145 @@ func TestDownloadAssetSupportedExtensionPDF(t *testing.T) {
 
 	if _, err := os.Stat(filename); err != nil {
 		t.Fatalf("expected file to exist: %v", err)
+	}
+}
+
+func TestCleanupDeletedPagesRemovesStaleMarkdownOnFullExport(t *testing.T) {
+	tmpDir := t.TempDir()
+	liveFile := filepath.Join(tmpDir, "live.md")
+	staleFile := filepath.Join(tmpDir, "stale.md")
+	keepTextFile := filepath.Join(tmpDir, "note.txt")
+
+	mustWriteFile(t, liveFile, "live")
+	mustWriteFile(t, staleFile, "stale")
+	mustWriteFile(t, keepTextFile, "keep")
+
+	e := &Exporter{
+		ExporterConfig: ExporterConfig{
+			Directory:      tmpDir,
+			CleanupDeleted: true,
+		},
+		exportedFiles: map[string]struct{}{
+			liveFile: {},
+		},
+	}
+
+	if err := e.cleanupDeletedPages(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertExists(t, liveFile)
+	assertNotExists(t, staleFile)
+	assertExists(t, keepTextFile)
+}
+
+func TestCleanupDeletedPagesIgnoresSubdirectoriesAndHiddenMarkdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	hiddenFile := filepath.Join(tmpDir, ".internal.md")
+	subDir := filepath.Join(tmpDir, "nested")
+	subFile := filepath.Join(subDir, "child.md")
+
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	mustWriteFile(t, hiddenFile, "hidden")
+	mustWriteFile(t, subFile, "nested")
+
+	e := &Exporter{
+		ExporterConfig: ExporterConfig{
+			Directory:      tmpDir,
+			CleanupDeleted: true,
+		},
+		exportedFiles: map[string]struct{}{},
+	}
+
+	if err := e.cleanupDeletedPages(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertExists(t, hiddenFile)
+	assertExists(t, subFile)
+}
+
+func TestCleanupDeletedPagesSkipsIncrementalExport(t *testing.T) {
+	tmpDir := t.TempDir()
+	staleFile := filepath.Join(tmpDir, "stale.md")
+	mustWriteFile(t, staleFile, "stale")
+
+	e := &Exporter{
+		ExporterConfig: ExporterConfig{
+			Directory:      tmpDir,
+			CleanupDeleted: true,
+			LookbackDays:   1,
+		},
+		exportedFiles: map[string]struct{}{},
+	}
+
+	if err := e.cleanupDeletedPages(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertExists(t, staleFile)
+}
+
+func TestCleanupDeletedPagesSkipsExecOne(t *testing.T) {
+	tmpDir := t.TempDir()
+	staleFile := filepath.Join(tmpDir, "stale.md")
+	mustWriteFile(t, staleFile, "stale")
+
+	e := &Exporter{
+		ExecOne: "page-id",
+		ExporterConfig: ExporterConfig{
+			Directory:      tmpDir,
+			CleanupDeleted: true,
+		},
+		exportedFiles: map[string]struct{}{},
+	}
+
+	if err := e.cleanupDeletedPages(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertExists(t, staleFile)
+}
+
+func TestCleanupDeletedPagesDisabledPreservesFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	staleFile := filepath.Join(tmpDir, "stale.md")
+	mustWriteFile(t, staleFile, "stale")
+
+	e := &Exporter{
+		ExporterConfig: ExporterConfig{
+			Directory:      tmpDir,
+			CleanupDeleted: false,
+		},
+		exportedFiles: map[string]struct{}{},
+	}
+
+	if err := e.cleanupDeletedPages(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertExists(t, staleFile)
+}
+
+func mustWriteFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+}
+
+func assertNotExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file to be deleted: %v, stat err: %v", path, err)
 	}
 }


### PR DESCRIPTION
## Summary
- add opt-in `cleanupDeleted` support for full exports
- reconcile top-level exported markdown files against the current run output
- add tests covering cleanup scope and skip conditions

## Testing
- `go test ./...` currently fails in this environment because the local Go installation is missing stdlib internal packages under `C:\Program Files\Go\src`